### PR TITLE
プレイヤーがエーテルを吸収できるように

### DIFF
--- a/Assets/SSP/Prefabs/Ether.prefab
+++ b/Assets/SSP/Prefabs/Ether.prefab
@@ -21,9 +21,11 @@ GameObject:
   - component: {fileID: 4018914029147890}
   - component: {fileID: 33092439685420476}
   - component: {fileID: 135168888094169298}
+  - component: {fileID: 135898202585162862}
   - component: {fileID: 23069619562125160}
   - component: {fileID: 54270739398327058}
   - component: {fileID: 114295420870100116}
+  - component: {fileID: 114882940585944346}
   m_Layer: 0
   m_Name: Ether
   m_TagString: Untagged
@@ -38,7 +40,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1768416262091988}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.54087967, y: 0.41430807, z: 0.6873363}
+  m_LocalPosition: {x: -4.3, y: 0.41430807, z: 0.6873363}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -111,7 +113,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   etherValue: 0
   originEtherSize: 0.01
+  triggerSize: 1
   floatHeight: 1
+--- !u!114 &114882940585944346
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1768416262091988}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1c238a9b14045b04eb5474dd803533a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!135 &135168888094169298
 SphereCollider:
   m_ObjectHideFlags: 1
@@ -123,4 +137,16 @@ SphereCollider:
   m_Enabled: 1
   serializedVersion: 2
   m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!135 &135898202585162862
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1768416262091988}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 5
   m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/SSP/Prefabs/Ether.prefab
+++ b/Assets/SSP/Prefabs/Ether.prefab
@@ -113,8 +113,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   etherValue: 0
   originEtherSize: 0.01
-  triggerSize: 1
+  triggerSize: 3
   floatHeight: 1
+  trackingSpeed: 3
 --- !u!114 &114882940585944346
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/SSP/Prefabs/Ether.prefab
+++ b/Assets/SSP/Prefabs/Ether.prefab
@@ -25,8 +25,7 @@ GameObject:
   - component: {fileID: 23069619562125160}
   - component: {fileID: 54270739398327058}
   - component: {fileID: 114295420870100116}
-  - component: {fileID: 114882940585944346}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: Ether
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -115,18 +114,8 @@ MonoBehaviour:
   originEtherSize: 0.01
   triggerSize: 3
   floatHeight: 1
-  trackingSpeed: 3
---- !u!114 &114882940585944346
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1768416262091988}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1c238a9b14045b04eb5474dd803533a9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  trackingSpeed: 5
+  target: {fileID: 0}
 --- !u!135 &135168888094169298
 SphereCollider:
   m_ObjectHideFlags: 1

--- a/Assets/SSP/Prefabs/Player.prefab
+++ b/Assets/SSP/Prefabs/Player.prefab
@@ -1686,7 +1686,7 @@ GameObject:
   - component: {fileID: 114858071444870302}
   m_Layer: 0
   m_Name: Player
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/SSP/Scripts/Common/IEther.cs
+++ b/Assets/SSP/Scripts/Common/IEther.cs
@@ -6,4 +6,5 @@ interface IEther
 {
     void SetEther(float ether);
     float GetEther();
+    void AcquireEther(float ether);
 }

--- a/Assets/SSP/Scripts/Player/PlayerEtherManager.cs
+++ b/Assets/SSP/Scripts/Player/PlayerEtherManager.cs
@@ -60,7 +60,7 @@ public class PlayerEtherManager : MonoBehaviour, IEther
             if (emitEtherValue < singleEtherValue)
                 singleEtherValue = emitEtherValue;
             emitEtherValue -= singleEtherValue;
-            emittedEtherObject.GetComponent<EtherObject>().SetEther(singleEtherValue);
+            emittedEtherObject.GetComponent<EtherObject>().Init(singleEtherValue);
             emithigh += emittedEtherObject.transform.localScale.y;      //SetEtherでemittedEtherObjectのサイズが変更されることに依存する
 
             var emitDirection = Vector3.up + new Vector3(Random.Range(-emitPower, emitPower), 0, Random.Range(-emitPower, emitPower));

--- a/Assets/SSP/Scripts/Utility/LayerMap.cs
+++ b/Assets/SSP/Scripts/Utility/LayerMap.cs
@@ -11,6 +11,7 @@ public static class LayerMap
 	public const int Attack = 8;
 	public const int Invincible = 9;
 	public const int Stage = 10;
+	public const int EtherObject = 11;
 	public const int DefaultMask = 1;
 	public const int TransparentFXMask = 2;
 	public const int IgnoreRaycastMask = 4;
@@ -19,4 +20,5 @@ public static class LayerMap
 	public const int AttackMask = 256;
 	public const int InvincibleMask = 512;
 	public const int StageMask = 1024;
+	public const int EtherObjectMask = 2048;
 }

--- a/Assets/SSP/Scripts/Utility/TagMap.cs
+++ b/Assets/SSP/Scripts/Utility/TagMap.cs
@@ -1,0 +1,13 @@
+﻿/// <summary>
+/// タグ名を定数で管理するクラス
+/// </summary>
+public static class TagMap
+{
+	public const string Untagged = "Untagged";
+	public const string Respawn = "Respawn";
+	public const string Finish = "Finish";
+	public const string EditorOnly = "EditorOnly";
+	public const string MainCamera = "MainCamera";
+	public const string Player = "Player";
+	public const string GameController = "GameController";
+}

--- a/Assets/SSP/Scripts/Utility/TagMap.cs.meta
+++ b/Assets/SSP/Scripts/Utility/TagMap.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 720a9763880103145adfa49d10c0da46
+timeCreated: 1504339587
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SSP/Scripts/items/EtherObject.cs
+++ b/Assets/SSP/Scripts/items/EtherObject.cs
@@ -22,7 +22,7 @@ public class EtherObject : MonoBehaviour
     private RaycastHit absorbHit;
     private int absorbLayerMask = ~(1 << LayerMap.EtherObject);
     //[SyncVar]
-    public GameObject target;
+    private GameObject target;
 
     private void Start()
     {
@@ -48,7 +48,6 @@ public class EtherObject : MonoBehaviour
         //targetを追従
         this.UpdateAsObservable()
             .Where(_ => target != null)
-            .Do(_ => Debug.Log(target.name))
             .Subscribe(_ => rigid.AddForce((target.transform.position - transform.position) * trackingSpeed, ForceMode.Force));
 
         //targetに衝突時に消滅・吸収

--- a/Assets/SSP/Scripts/items/EtherObject.cs
+++ b/Assets/SSP/Scripts/items/EtherObject.cs
@@ -33,7 +33,7 @@ public class EtherObject : MonoBehaviour
         this.OnTriggerStayAsObservable()
             .Where(col => col.gameObject.tag == TagMap.Player)
             .Where(col => col.GetComponent<PlayerHealthManager>().IsAlive())
-            .Where(col => Physics.Raycast(transform.position, col.transform.position - transform.position, out hit, 10000))
+            .Where(col => Physics.Raycast(transform.position, col.transform.position - transform.position, out hit, 100))
             .Subscribe(col =>
             {
                 rigid.AddForce((col.transform.position - transform.position) * trackingSpeed, ForceMode.Force);

--- a/Assets/SSP/Scripts/items/EtherObject.cs
+++ b/Assets/SSP/Scripts/items/EtherObject.cs
@@ -35,6 +35,7 @@ public class EtherObject : MonoBehaviour
 
         //trigger圏内のPlayerのRayをとばして、障害物がなければtargetに指定
         this.OnTriggerEnterAsObservable()
+            .Where(_ => target == null)
             .Where(col => col.gameObject.tag == TagMap.Player)
             .Where(col => col.GetComponent<PlayerHealthManager>().IsAlive())
             .Where(col => Physics.Raycast(transform.position, col.transform.position - transform.position, out playerHit, 100))

--- a/Assets/SSP/Scripts/items/EtherObject.cs
+++ b/Assets/SSP/Scripts/items/EtherObject.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UniRx;
+using UniRx.Triggers;
 
 public class EtherObject : MonoBehaviour
 {
@@ -16,18 +18,16 @@ public class EtherObject : MonoBehaviour
     private void Start()
     {
         rigid = GetComponent<Rigidbody>();
-    }
+        var col = GetComponent<SphereCollider>();
 
-    private void Update()
-    {
-        if (Physics.Raycast(transform.position, Vector3.down, out hit, floatHeight * 10, layerMask))
-        {
-            var high = Vector3.Distance(transform.position, hit.point);
-            if (high < floatHeight)
+        this.UpdateAsObservable()
+            .Where(_ => Physics.Raycast(transform.position, Vector3.down, out hit, floatHeight * 10, layerMask))
+            .Where(_ => Vector3.Distance(transform.position, hit.point) < floatHeight)
+            .Take(1)
+            .Subscribe(_ =>
             {
                 rigid.useGravity = false;
-            }
-        }
+            });
     }
 
     public void SetEther(float value)

--- a/Assets/SSP/Scripts/items/EtherObject.cs
+++ b/Assets/SSP/Scripts/items/EtherObject.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UniRx;
 using UniRx.Triggers;
+using System.Linq;
 
 public class EtherObject : MonoBehaviour
 {
@@ -10,29 +11,36 @@ public class EtherObject : MonoBehaviour
     public float etherValue;
 
     [SerializeField] private float originEtherSize;
+    [SerializeField] private float triggerSize = 0.5f;
     [SerializeField] private float floatHeight;
-    private Rigidbody rigid;
+    private SphereCollider trigger;
+
     private RaycastHit hit;
     private int layerMask = 1 << LayerMap.Stage;
 
     private void Start()
     {
-        rigid = GetComponent<Rigidbody>();
-        var col = GetComponent<SphereCollider>();
+        var rigid = GetComponent<Rigidbody>();
 
         this.UpdateAsObservable()
             .Where(_ => Physics.Raycast(transform.position, Vector3.down, out hit, floatHeight * 10, layerMask))
             .Where(_ => Vector3.Distance(transform.position, hit.point) < floatHeight)
             .Take(1)
-            .Subscribe(_ =>
-            {
-                rigid.useGravity = false;
-            });
+            .Subscribe(_ => rigid.useGravity = false);
     }
 
-    public void SetEther(float value)
+    public void Init(float value)
     {
         etherValue = value;
         transform.localScale = Vector3.one * originEtherSize * value;
+        if (transform.localScale.x < 1)
+            GetTrigger().radius = triggerSize / transform.localScale.x;
+    }
+
+    private SphereCollider GetTrigger()
+    {
+        if (trigger != null) return trigger;
+        trigger = GetComponents<SphereCollider>().Where(v => v.isTrigger).First();
+        return trigger;
     }
 }

--- a/Assets/SSP/Scripts/items/EtherObject.cs
+++ b/Assets/SSP/Scripts/items/EtherObject.cs
@@ -44,6 +44,10 @@ public class EtherObject : MonoBehaviour
         this.UpdateAsObservable()
             .Where(_ => target != null)
             .Subscribe(_ => rigid.AddForce((target.transform.position - transform.position) * trackingSpeed, ForceMode.Force));
+
+        this.OnCollisionEnterAsObservable()
+            .Where(col => col.gameObject == target)
+            .Subscribe(_ => Destroy(this.gameObject));
     }
 
     public void Init(float value)

--- a/Assets/SSP/Scripts/items/EtherObject.cs
+++ b/Assets/SSP/Scripts/items/EtherObject.cs
@@ -33,15 +33,17 @@ public class EtherObject : MonoBehaviour
             .Take(1)
             .Subscribe(_ => rigid.useGravity = false);
 
-        this.OnTriggerStayAsObservable()
+        //trigger圏内のPlayerのRayをとばして、障害物がなければtargetに指定
+        this.OnTriggerEnterAsObservable()
             .Where(col => col.gameObject.tag == TagMap.Player)
             .Where(col => col.GetComponent<PlayerHealthManager>().IsAlive())
             .Where(col => Physics.Raycast(transform.position, col.transform.position - transform.position, out playerHit, 100))
             .Where(_ => playerHit.collider.gameObject.tag == TagMap.Player)
             .Subscribe(col => target = col.gameObject);
-            {
-                rigid.AddForce((col.transform.position - transform.position) * trackingSpeed, ForceMode.Force);
-            });
+
+        this.UpdateAsObservable()
+            .Where(_ => target != null)
+            .Subscribe(_ => rigid.AddForce((target.transform.position - transform.position) * trackingSpeed, ForceMode.Force));
     }
 
     public void Init(float value)

--- a/Assets/SSP/Scripts/items/EtherObject.cs
+++ b/Assets/SSP/Scripts/items/EtherObject.cs
@@ -20,6 +20,7 @@ public class EtherObject : MonoBehaviour
     private int layerMask = 1 << LayerMap.Stage;
 
     private RaycastHit playerHit;
+    //[SyncVar]
     private GameObject target;
 
     private void Start()
@@ -50,7 +51,11 @@ public class EtherObject : MonoBehaviour
         //targetに衝突時に消滅・吸収
         this.OnCollisionEnterAsObservable()
             .Where(col => col.gameObject == target)
-            .Subscribe(_ => Destroy(this.gameObject));
+            .Subscribe(_ =>
+            {
+                target.GetComponent<IEther>().AcquireEther(etherValue);
+                Destroy(this.gameObject);
+            });
     }
 
     public void Init(float value)

--- a/Assets/SSP/Scripts/items/EtherObject.cs
+++ b/Assets/SSP/Scripts/items/EtherObject.cs
@@ -41,10 +41,12 @@ public class EtherObject : MonoBehaviour
             .Where(_ => playerHit.collider.gameObject.tag == TagMap.Player)
             .Subscribe(col => target = col.gameObject);
 
+        //targetを追従
         this.UpdateAsObservable()
             .Where(_ => target != null)
             .Subscribe(_ => rigid.AddForce((target.transform.position - transform.position) * trackingSpeed, ForceMode.Force));
 
+        //targetに衝突時に消滅・吸収
         this.OnCollisionEnterAsObservable()
             .Where(col => col.gameObject == target)
             .Subscribe(_ => Destroy(this.gameObject));
@@ -58,6 +60,7 @@ public class EtherObject : MonoBehaviour
             GetTrigger().radius = triggerSize / transform.localScale.x;
     }
 
+    //Startより先にInitが呼ばれるため、triggerの取得はこのようになった
     private SphereCollider GetTrigger()
     {
         if (trigger != null) return trigger;

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -16,7 +16,7 @@ TagManager:
   - Attack
   - Invincible
   - Stage
-  - 
+  - EtherObject
   - 
   - 
   - 


### PR DESCRIPTION
### Issue
https://github.com/denx-jp/SSP/issues/4

### Update
- [ ] プレイヤーがエーテルに当たったらエーテルオブジェクト削除
- [ ] プレイヤーのエーテル保持量がエーテルオブジェクトが持っていた分だけ増加する